### PR TITLE
fix fetching of system types

### DIFF
--- a/app/js/api/system.js
+++ b/app/js/api/system.js
@@ -20,7 +20,6 @@ function System(
     DataUtils) {
 
     var root = InsightsConfig.apiRoot;
-    var _systemTypesDfd;
     var _systemDfd;
     var _systemStatusDfd;
 
@@ -133,19 +132,12 @@ function System(
         },
 
         getSystemTypes: function () {
-            var url;
+            const url = root + 'system_types';
 
-            if (_systemTypesDfd) {
-                return _systemTypesDfd;
-            }
-
-            url = root + 'system_types';
-            _systemTypesDfd = $http.get(url);
-            _systemTypesDfd.then(function (response) {
-                return decorateSystemTypes(response.data);
+            return $http.get(url).then(function (response) {
+                decorateSystemTypes(response.data);
+                return response;
             });
-
-            return _systemTypesDfd;
         },
 
         getSystems: function () {

--- a/app/js/components/actions/actionsRule/actionsRule.controller.js
+++ b/app/js/components/actions/actionsRule/actionsRule.controller.js
@@ -195,8 +195,6 @@ function ActionsRuleCtrl(
                 RhaTelemetryActionsService.setIsScrolling(false);
             });
 
-        let systemTypesPromise = SystemsService.populateSystemTypes(false);
-
         let topicBreadCrumbPromise =
             Topic.get($stateParams.category).success(function (topic) {
                 ActionsBreadcrumbs.setCrumb({
@@ -210,8 +208,8 @@ function ActionsRuleCtrl(
 
         let productSpecific = System.getProductSpecificData();
 
-        $q.all([populateDetailsPromise, systemTypesPromise, topicBreadCrumbPromise,
-            productSpecific])
+        $q.all([populateDetailsPromise, SystemsService.getSystemTypesAsync(),
+            topicBreadCrumbPromise, productSpecific])
             .finally(function () {
                 $scope.loading = false;
                 priv.initialDisplay();

--- a/app/js/components/card/systemCard/systemCard.directive.js
+++ b/app/js/components/card/systemCard/systemCard.directive.js
@@ -44,71 +44,70 @@ function systemCardCtrl(
         $scope.loading = true;
         System.getSystemLinks($scope.system.system_id, query).then(function (links) {
                 var linkGroups;
-                var types;
                 var rolePriorities;
 
                 if (links && links.data && links.data.resources) {
-                    $scope.links = links.data.resources;
-                    linkGroups = groupBy($scope.links, function (link) {
-                        return link.system_type_id;
-                    });
+                    SystemsService.getSystemTypesAsync().then(function (types) {
+                        $scope.links = links.data.resources;
+                        linkGroups = groupBy($scope.links, function (link) {
+                            return link.system_type_id;
+                        });
 
-                    types = SystemsService.getSystemTypes();
+                        //most important role is first
+                        rolePriorities = [find(types, {
+                            product_code: Products.osp.code,
+                            role: Products.osp.roles.cluster.code
+                        }),find(types, {
+                            product_code: Products.rhev.code,
+                            role: Products.rhev.roles.cluster.code
+                        }),find(types, {
+                            product_code: Products.ocp.code,
+                            role: Products.ocp.roles.cluster.code
+                        }),find(types, {
+                            product_code: Products.osp.code,
+                            role: Products.osp.roles.director.code
+                        }),find(types, {
+                            product_code: Products.rhev.code,
+                            role: Products.rhev.roles.manager.code
+                        }),find(types, {
+                            product_code: Products.ocp.code,
+                            role: Products.ocp.roles.master.code
+                        }),find(types, {
+                            product_code: Products.docker.code,
+                            role: Products.docker.roles.host.code
+                        }),find(types, {
+                            product_code: Products.osp.code,
+                            role: Products.osp.roles.compute.code
+                        }),find(types, {
+                            product_code: Products.osp.code,
+                            role: Products.osp.roles.controller.code
+                        }),find(types, {
+                            product_code: Products.rhev.code,
+                            role: Products.rhev.roles.hypervisor.code
+                        }),find(types, {
+                            product_code: Products.docker.code,
+                            role: Products.docker.roles.container.code
+                        }),find(types, {
+                            product_code: Products.docker.code,
+                            role: Products.docker.roles.image.code
+                        }),find(types, {
+                            product_code: Products.ocp.code,
+                            role: Products.ocp.roles.node.code
+                        }),find(types, {
+                            product_code: Products.rhel.code,
+                            role: Products.rhel.roles.host.code
+                        })];
 
-                    //most important role is first
-                    rolePriorities = [find(types, {
-                        product_code: Products.osp.code,
-                        role: Products.osp.roles.cluster.code
-                    }),find(types, {
-                        product_code: Products.rhev.code,
-                        role: Products.rhev.roles.cluster.code
-                    }),find(types, {
-                        product_code: Products.ocp.code,
-                        role: Products.ocp.roles.cluster.code
-                    }),find(types, {
-                        product_code: Products.osp.code,
-                        role: Products.osp.roles.director.code
-                    }),find(types, {
-                        product_code: Products.rhev.code,
-                        role: Products.rhev.roles.manager.code
-                    }),find(types, {
-                        product_code: Products.ocp.code,
-                        role: Products.ocp.roles.master.code
-                    }),find(types, {
-                        product_code: Products.docker.code,
-                        role: Products.docker.roles.host.code
-                    }),find(types, {
-                        product_code: Products.osp.code,
-                        role: Products.osp.roles.compute.code
-                    }),find(types, {
-                        product_code: Products.osp.code,
-                        role: Products.osp.roles.controller.code
-                    }),find(types, {
-                        product_code: Products.rhev.code,
-                        role: Products.rhev.roles.hypervisor.code
-                    }),find(types, {
-                        product_code: Products.docker.code,
-                        role: Products.docker.roles.container.code
-                    }),find(types, {
-                        product_code: Products.docker.code,
-                        role: Products.docker.roles.image.code
-                    }),find(types, {
-                        product_code: Products.ocp.code,
-                        role: Products.ocp.roles.node.code
-                    }),find(types, {
-                        product_code: Products.rhel.code,
-                        role: Products.rhel.roles.host.code
-                    })];
-
-                    $scope.linkGroups = map(linkGroups, function (value, key) {
-                        var priority = findIndex(
-                            rolePriorities,
-                            {id: parseInt(key)});
-                        return {
-                            priority: priority,
-                            system_type_id: key,
-                            members: value
-                        };
+                        $scope.linkGroups = map(linkGroups, function (value, key) {
+                            var priority = findIndex(
+                                rolePriorities,
+                                {id: parseInt(key)});
+                            return {
+                                priority: priority,
+                                system_type_id: key,
+                                members: value
+                            };
+                        });
                     });
                 }
             }).then(function () {

--- a/app/js/components/linkGroup/linkGroup.directive.js
+++ b/app/js/components/linkGroup/linkGroup.directive.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var componentsModule = require('../');
-var find = require('lodash/collection/find');
 
 /**
  * @ngInject
@@ -25,9 +24,9 @@ function linkGroupCtrl($scope, $state, InventoryService, SystemsService) {
         return hasReports;
     };
 
-    $scope.getLinkGroupText = function () {
-        var type = find(SystemsService.getSystemTypes(), {id: parseInt($scope.typeid)});
-        var text = '';
+    SystemsService.getSystemTypeAsync($scope.typeid).then(function (type) {
+        let text = '';
+
         if (type) {
             text = $scope.group.length + ' ' + type.displayName;
             if ($scope.group.length !== 1) {
@@ -35,8 +34,8 @@ function linkGroupCtrl($scope, $state, InventoryService, SystemsService) {
             }
         }
 
-        return text;
-    };
+        $scope.linkGroupText = text;
+    });
 
     $scope.getLinkReportCount = function (link) {
         var report_count = link.report_count;

--- a/app/js/components/linkGroup/linkGroup.jade
+++ b/app/js/components/linkGroup/linkGroup.jade
@@ -16,7 +16,7 @@
           tooltip-trigger='mouseenter',
           tooltip-append-to-body='true',
           tooltip-placement='top')
-    | {{getLinkGroupText(type_id)}}
+    | {{linkGroupText}}
   .member-group-content(ng-if='!collapsed')
     .row
       .link-text(ng-repeat='link in group')

--- a/app/js/components/maintenance/maintenancePlan/maintenancePlan.directive.js
+++ b/app/js/components/maintenance/maintenancePlan/maintenancePlan.directive.js
@@ -7,6 +7,7 @@ const find = require('lodash/collection/find');
 const FileSaver = require('file-saver');
 const parseHeader = require('parse-http-header');
 const some = require('lodash/collection/some');
+const get = require('lodash/object/get');
 
 /**
  * @ngInject
@@ -311,7 +312,9 @@ function maintenancePlanCtrl(
     };
 
     $scope.groupBySystemType = function (system) {
-        return SystemsService.getSystemTypeDisplayName(system.system_type_id);
+        // this is safe as system select won't be shown before system types are loaded
+        return get(SystemsService.getSystemTypeUnsafe(system.system_type_id),
+            'displayName');
     };
 
     function checkAnsibleSupport () {

--- a/app/js/components/maintenance/maintenancePlan/maintenancePlan.jade
+++ b/app/js/components/maintenance/maintenancePlan/maintenancePlan.jade
@@ -215,7 +215,8 @@
                   ui-select.gray.maintenance-page-select(
                     ng-model='addSystem.selected',
                     append-to-body='false',
-                    ng-disabled='!getAvailableSystems().length')
+                    ng-disabled='!getAvailableSystems().length',
+                    ng-if='systemTypes.length')
                     ui-select-match.form-control.ui-select-match(placeholder="{{'Add system' | translate}}")
                       | {{$select.selected._displayAs}}
                     ui-select-choices.ui-select-choices(

--- a/app/js/components/maintenance/maintenancePlaybook/maintenancePlaybook.controller.js
+++ b/app/js/components/maintenance/maintenancePlaybook/maintenancePlaybook.controller.js
@@ -35,17 +35,19 @@ function MaintenancePlaybook($modalInstance,
         $scope.currentQuestion = null;
         $scope.listLimit = $scope.MINIMUM_NUMBER_OF_ITEMS;
 
-        if (unsupportedRules === null) {
-            AnsibleService.init(questions,
-                                $scope.plan,
-                                false);
-            $scope.questions = AnsibleService.questions;
-            $scope.systemSummary = AnsibleService.getSystemSummary();
-        } else {
-            setRulesWithoutPlays();
-        }
+        // make sure system types are loaded before going further
+        SystemsService.getSystemTypesAsync().then(function () {
+            if (unsupportedRules === null) {
+                AnsibleService.init(questions,
+                    $scope.plan,
+                    false);
+                $scope.questions = AnsibleService.questions;
+            } else {
+                setRulesWithoutPlays();
+            }
 
-        initStep();
+            initStep();
+        });
     }
 
     $scope.close = function () {
@@ -88,7 +90,9 @@ function MaintenancePlaybook($modalInstance,
 
             let ruleWithoutPlay = {
                 rule_id: rule.rule_id,
-                system_type: SystemsService.getSystemType(rule.system_type_id),
+
+                // this is safe as system types are awaited within init()
+                system_type: SystemsService.getSystemTypeUnsafe(rule.system_type_id),
                 description: fullRule.description,
                 category: fullRule.category,
                 severity: fullRule.severity,
@@ -133,7 +137,9 @@ function MaintenancePlaybook($modalInstance,
                         rule_id: rule.rule_id,
                         category: rule.category,
                         description: rule.description,
-                        system_type: SystemsService.getSystemType(
+
+                        // this is safe as system types are awaited within init()
+                        system_type: SystemsService.getSystemTypeUnsafe(
                             action.system.system_type_id)
                     };
 
@@ -265,7 +271,8 @@ function MaintenancePlaybook($modalInstance,
         $scope.currentQuestion.resolution_type =
             AnsibleService.getResolutionType($scope.currentQuestion);
 
-        $scope.currentQuestion.system_type = SystemsService.getSystemType(
+        // this is safe as system types are awaited within init()
+        $scope.currentQuestion.system_type = SystemsService.getSystemTypeUnsafe(
             $scope.currentQuestion.system_type_id);
 
         // gets systems that match the rule and system type for the current question

--- a/app/js/components/rule/ruleDebug/ruleDebug.directive.js
+++ b/app/js/components/rule/ruleDebug/ruleDebug.directive.js
@@ -84,10 +84,6 @@ function RuleDebugCtrl(
 
     $scope.buildPreview();
 
-    SystemsService.populateSystemTypes(false).then(function () {
-        $scope.systemTypes = SystemsService.getSystemTypes();
-    });
-
     // TODO: workaround for https://trello.com/c/Ps2lXYGr/21
     function readSystem (r) {
         r.system.toString = Utils.getSystemDisplayName(r.system);

--- a/app/js/components/typeIcon/typeIcon.directive.js
+++ b/app/js/components/typeIcon/typeIcon.directive.js
@@ -9,13 +9,14 @@ function typeIconCtrl($scope, SystemsService) {
     $scope.systemTypeIcon = '';
     $scope.systemTypeDisplayName = '';
     $scope.systemTypeDisplayNameShort = '';
-    let systemType = SystemsService.getSystemType($scope.typeId);
 
-    if (systemType) {
-        $scope.systemTypeIcon = systemType.imageClass;
-        $scope.systemTypeDisplayName = systemType.displayName;
-        $scope.systemTypeDisplayNameShort = systemType.displayNameShort;
-    }
+    SystemsService.getSystemTypeAsync($scope.typeId).then(function (systemType) {
+        if (systemType) {
+            $scope.systemTypeIcon = systemType.imageClass;
+            $scope.systemTypeDisplayName = systemType.displayName;
+            $scope.systemTypeDisplayNameShort = systemType.displayNameShort;
+        }
+    });
 }
 
 function typeIcon() {

--- a/app/js/services/ansible.service.js
+++ b/app/js/services/ansible.service.js
@@ -1,12 +1,11 @@
 'use strict';
 
 var servicesModule = require('./');
-const pluck = require('lodash/collection/pluck');
 
 /**
  * @ngInject
  */
-function AnsibleService(SystemsService) {
+function AnsibleService() {
 
     var ansibleService = {};
     var plan = null;
@@ -107,42 +106,6 @@ function AnsibleService(SystemsService) {
         }
 
         return formattedResolutions;
-    };
-
-    /**
-     * Gathers all systems that have actions that will be resolved by the generated
-     * playbook and organizes them by their system_type
-     */
-    ansibleService.getSystemSummary = function () {
-        let systemSummary = {};
-
-        // gets the list of rules that have an ansible_resolution for this plan
-        let ruleList = plan.rules.filter((rule) => {
-            return pluck(ansibleService.questions, 'rule_id')
-                   .includes(rule.rule_id);
-        });
-
-        // Creates a hashmap of {product_code: {system_type<Object>, systems<Array>}}:
-        // 1) Gets each system from the actions of the rules in ruleList
-        // 2) Creates a new hask key using the system_type.product_code if doesn't exist
-        // 3) Adds the system_type object to the object of this hash
-        // 4) Adds the system object to the object of this hash
-        ruleList.forEach((rule) => {
-            let systemType = null;
-            rule.actions.forEach((action) => {
-                systemType = SystemsService.getSystemType(action.system.system_type_id);
-                if (systemType.product_code in systemSummary) {
-                    systemSummary[systemType.product_code].systems.push(action.system);
-                } else {
-                    systemSummary[systemType.product_code] = {
-                        system_type: systemType,
-                        systems: [action.system]
-                    };
-                }
-            });
-        });
-
-        return systemSummary;
     };
 
     return ansibleService;

--- a/app/js/states/inventory/inventory.controller.js
+++ b/app/js/states/inventory/inventory.controller.js
@@ -99,7 +99,7 @@ function InventoryCtrl(
     function initInventory() {
         //get system types
         $scope.loading = true;
-        SystemsService.populateSystemTypes(false).then(function () {
+        SystemsService.getSystemTypesAsync().then(function () {
             getData(false);
         });
     }
@@ -269,7 +269,9 @@ function InventoryCtrl(
             role: 'hypervisor'
         }];
         var systemType = pick(
-            find(SystemsService.getSystemTypes(), {id: system.system_type_id}),
+
+            // this is safe as system types are awaited within initInventory()
+            SystemsService.getSystemTypeUnsafe(system.system_type_id),
             'product_code',
             'role');
 

--- a/app/js/states/maintenance/maintenance.controller.js
+++ b/app/js/states/maintenance/maintenance.controller.js
@@ -159,14 +159,7 @@ function MaintenanceCtrl(
     PermalinkService,
     $state,
     $rootScope,
-    DataUtils,
-    System,
     SystemsService) {
-
-    $scope.systemTypes = [];
-    SystemsService.populateSystemTypes(false).then(function () {
-        $scope.systemTypes = SystemsService.getSystemTypes();
-    });
 
     $scope.BasicEditHandler = BasicEditHandler;
     $scope.available = MaintenanceService.available;
@@ -282,6 +275,10 @@ function MaintenanceCtrl(
     });
 
     MaintenanceService.loadAvailableSystemsAndRules();
+
+    SystemsService.getSystemTypesAsync().then(function (systemTypes) {
+        $scope.systemTypes = systemTypes;
+    });
 
     $rootScope.$on('reload:data', function () {
         $scope.loader.loading = false; // disable loader throttling for reload


### PR DESCRIPTION
This change eliminates race conditions where some logic would run assuming system types have been already loaded even though they were not.
Given that almost every controller works with system types one way or another I switched to eagerly loading system types once SystemsService is used for the first time.

https://trello.com/c/fkoQOXUw/125-type-column-reported-empty-by-customer