### PR TITLE
fixes default sorting to use toString instead of hostname

### DIFF
--- a/app/js/components/actions/actionsRule/actionsRule.controller.js
+++ b/app/js/components/actions/actionsRule/actionsRule.controller.js
@@ -108,7 +108,7 @@ function ActionsRuleCtrl(
     $scope.getReportDetails = RhaTelemetryActionsService.getReportDetails;
     $scope.loading = true;
     $scope.loadingSystems = true;
-    $scope.predicate = 'system.hostname';
+    $scope.predicate = 'toString';
     $scope.ospRuleResolution = '';
 
     $scope.search = {


### PR DESCRIPTION
One liner to fix the default sorting on page 3 of actions.