### PR TITLE
removes previous button from ansible modal

### DIFF
--- a/app/js/components/maintenance/maintenancePlaybook/maintenancePlaybook.jade
+++ b/app/js/components/maintenance/maintenancePlaybook/maintenancePlaybook.jade
@@ -137,7 +137,7 @@
 .modal-footer
   ul.row.pager.pager-steps(ng-if='step === RESOLVE_QUESTIONS || step === SUMMARY')
     li.previous.col-sm-6
-      a.btn.btn-accent(ng-click='prevStep()', translate)
+      a.btn.btn-accent(ng-click='prevStep()', ng-if='(step !== RESOLVE_QUESTIONS || rulesWithoutPlays.length > 0) && currentQuestion.index > 0)', translate)
         i.fa.fa-chevron-left
         | &nbsp;&nbsp;Previous
     li.next.col-sm-6(ng-if='step !== SUMMARY')


### PR DESCRIPTION
Removes previous button from ansible modal for first question if there are no actions without playbooks for given plan

https://trello.com/c/HYQq3o3j/147-previous-on-generate-plan-leads-to-dead-end