### PR TITLE
[ubersev] swap out the severity typed icons, they needed to be slightly bigger...

### DIFF
--- a/app/styles/components/_severity-icon.scss
+++ b/app/styles/components/_severity-icon.scss
@@ -5,13 +5,13 @@
   &.severity i.high { background-image: url('../images/i_high-bordered.svg'); }
   &.severity i.critical { background-image: url('../images/i_critical-bordered.svg'); }
   &.severity i {
-    width: 20px;
-    height: 24px;
+    width: 24px;
+    height: 28px;
   }
 
   i {
-    width: 16px;
-    height: 20px;
+    width: 24px;
+    height: 28px;
     display: inline-block;
     background-repeat: no-repeat;
     background-position: center center;
@@ -20,6 +20,12 @@
     &.med { background-image: url('../images/i_med.svg'); }
     &.high { background-image: url('../images/i_high.svg'); }
     &.critical { background-image: url('../images/i_critical.svg'); }
+
+    &.low,
+    &.med,
+    &.high {
+      background-position: center bottom;
+    }
 
     &.unknown { text-align: center; }
     &.unknown:after {
@@ -42,9 +48,9 @@
 }
 
 table {
-  .severity-icon {
-    i.low { background-image: url('../images/i_low-table.svg'); }
-    i.med { background-image: url('../images/i_med-table.svg'); }
-    i.high { background-image: url('../images/i_high-table.svg'); }
-  }
+  //.severity-icon {
+  //  i.low { background-image: url('../images/i_low-table.svg'); }
+  //  i.med { background-image: url('../images/i_med-table.svg'); }
+  //  i.high { background-image: url('../images/i_high-table.svg'); }
+  //}
 }


### PR DESCRIPTION
... because the svg size of the bordered icon is slighly larger, thus it gets compressed in the same width/height container
This could be avoided if the two image sets have the same h/w