### PR TITLE
[digests] make a new filter to getDisplayName and use it

### DIFF
--- a/app/js/components/filters/filters.js
+++ b/app/js/components/filters/filters.js
@@ -1,3 +1,4 @@
+/*global require, angular*/
 'use strict';
 
 var componentsModule = require('../');
@@ -190,6 +191,12 @@ function timeAgo () {
     };
 }
 
+function getSystemDisplayName (Utils) {
+    return function (system) {
+        return Utils.getSystemDisplayName(system);
+    };
+}
+
 componentsModule.filter('trust_html', trust_html);
 componentsModule.filter('titlecase', titlecase);
 componentsModule.filter('sortClass', sortClass);
@@ -200,6 +207,7 @@ componentsModule.filter('toWidth', toWidth);
 componentsModule.filter('checkInStyle', checkInStyle);
 componentsModule.filter('searchMaintenancePlans', searchMaintenancePlans);
 componentsModule.filter('moment', momentFilter);
+componentsModule.filter('getSystemDisplayName', getSystemDisplayName);
 componentsModule.filter('isEmpty', function () {
     return isEmpty;
 });

--- a/app/js/states/digests/digests.jade
+++ b/app/js/states/digests/digests.jade
@@ -60,8 +60,6 @@
                 td
                   severity-icon(severity='rule.severity', type='severity', label='')
 
-
-
     section
       .row
         .col-md-6
@@ -75,7 +73,7 @@
             tbody
               tr(ng-repeat='system in topTenWorstSystems')
                 td.hostname
-                  a(ng-click='showSystem(system)') {{ system.hostname }}
+                  a(ng-click='showSystem(system)') {{ system | getSystemDisplayName }}
                 td {{ system.report_count }}
 
         .col-md-6


### PR DESCRIPTION
I was thinking about switching all usage of Utils.getSystemDisplayName throughout the app to use this new filter instead of using getSystemDisplayName directly.

Thoughts?