### PR TITLE
[deps] updated prod deps and moved urijs to dev deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,12 +8,11 @@
   },
   "private": true,
   "dependencies": {
-    "compression": "1.5.0",
-    "express": "4.12.4",
-    "file-saver": "^1.3.3",
-    "morgan": "1.5.3",
-    "parse-http-header": "^1.0.0",
-    "urijs": "^1.17.1"
+    "compression": "~1.6.2",
+    "express": "~4.15.2",
+    "file-saver": "~1.3.3",
+    "morgan": "~1.8.1",
+    "parse-http-header": "~1.0.0"
   },
   "devDependencies": {
     "babel-preset-es2015-without-strict": "0.0.2",
@@ -84,6 +83,7 @@
     "should": "^7.0.2",
     "tiny-lr": "0.1.5",
     "uglifyify": "3.0.1",
+    "urijs": "~1.17.1",
     "vinyl-buffer": "1.0.0",
     "vinyl-source-stream": "1.1.0"
   },


### PR DESCRIPTION
URI.js should only be needed at build time, right?

compression, express, and morgan updated to the latest stable release and changed to using ~ to get the latest point release. 