### PR TITLE
[stable] topics - granular control over which topics are listed

### DIFF
--- a/app/js/states/topics/controllers/edit.topics.controller.js
+++ b/app/js/states/topics/controllers/edit.topics.controller.js
@@ -102,7 +102,6 @@ function EditTopicCtrl(
             $scope.topic.rules = [];
         }
 
-        $scope.topicType = ($scope.topic.alwaysShow) ? 'always' : 'default';
         $scope.ruleBinding = $scope.topic.ruleBinding;
         $scope.updateTaggedRules();
     });
@@ -113,8 +112,8 @@ function EditTopicCtrl(
 
     function prepareUpdatePayload (topic) {
         var data = pick(topic,
-            ['id', 'title', 'summary', 'content',
-            'alwaysShow', 'tag', 'category', 'slug', 'severity']);
+            ['id', 'title', 'summary', 'content', 'hidden',
+            'listed', 'tag', 'category', 'slug', 'severity']);
 
         if ($scope.ruleBinding === 'tagged') {
             data.category = data.severity = null;

--- a/app/js/states/topics/views/edit-topics.jade
+++ b/app/js/states/topics/views/edit-topics.jade
@@ -24,16 +24,21 @@
             | Priority is determined from the order of topics in the &nbsp;
             a(ui-sref='app.admin-topic') topic admin table
       .form-group
-        label.control-label.col-sm-2 Topic type
+        label.control-label.col-sm-2 Topic listing behavior
+          i.fa.fa-question-circle.inline-left(tooltip='Controls when this topic shows up for a customer in the topic list (actions page).')
         .col-sm-10
           label.radio-inline
-            input#type1(type='radio', ng-model='topicType', value='default', ng-change='topic.alwaysShow = false')
-            | Shown if systems affected (default)&nbsp;
-            i.fa.fa-question-circle(tooltip='This topic will only be shown to a customer if at least one of their systems is affected. More precisely, the topic is shown if any of the active non-ignored rules associated with this topic (see below) has hits (unresolved actions) on customer\'s systems. If the customer used the product filter to select a particular product, the topic is only shown if there are hits for the selected product.')
+            input(type='radio', ng-model='topic.listed', ng-value="'always'")
+            | Always
+            i.fa.fa-question-circle.inline-left(tooltip='This topic will be shown always, no matter if customer\'s systems are affected or not. The topic content should use interpolation and conditionals to react to different scenarios (e.g. there are no hits, user has 0 systems registered, product with 0 hits selected, user ignored certain rules, ...)')
           label.radio-inline
-            input#type2(type='radio', ng-model='topicType', value='always', ng-change='topic.alwaysShow = true')
-            | Shown always&nbsp;
-            i.fa.fa-question-circle(tooltip='This topic will be shown always, no matter if customer\'s systems are affected or not. The topic content should use interpolation and conditionals to react to different scenarios (e.g. there are no hits, user has 0 systems registered, product with 0 hits selected, user ignored certain rules, ...)')
+            input(type='radio', ng-model='topic.listed', ng-value='"has_hits"')
+            | Systems affected
+            i.fa.fa-question-circle.inline-left(tooltip='This topic will only be shown to a customer if at least one of their systems is affected. More precisely, the topic is shown if any of the active non-ignored rules associated with this topic (see below) has hits (unresolved actions) on customer\'s systems. If the customer used the product filter to select a particular product, the topic is only shown if there are hits for the selected product.')
+          label.radio-inline
+            input(type='radio', ng-model='topic.listed', ng-value='"never"')
+            | Never
+            i.fa.fa-question-circle.inline-left(tooltip='This topic is never shown in the topic list. It can still be accessed by a direct link. It can also be used for backing a widget. Implicit topics (based on severity or category) will typically use this option.')
       .form-group(ng-class="{'has-error': error.content}")
         label.control-label.col-sm-2(for='content') Content
         .col-sm-10

--- a/app/js/states/topics/views/topic-admin.jade
+++ b/app/js/states/topics/views/topic-admin.jade
@@ -11,12 +11,12 @@
           th URL
           th Rules
           th
-          th
+            | Visibility
+            i.fa.fa-question-circle.inline-left(tooltip='Controls when this topic shows up for a customer in the topic list (actions page).')
+          th Actions
       tbody
         tr.ng-cloak(ng-repeat="topic in topics track by topic.id", ng-show='!loader.loading')
           td
-            span.icon-inline(ng-show='topic.hidden')
-              i.fa.fa-eye-slash(tooltip='This topic is hidden')
             a(ui-sref='app.topic({id: topic.slug ? topic.slug : topic.id})') {{topic.title}}
           td
             a(ui-sref='app.topic({id: topic.slug ? topic.slug : topic.id})') /actions/{{topic.slug ? topic.slug : topic.id}}
@@ -28,6 +28,12 @@
               em(ng-if='topic.category && topic.severity') ,&nbsp;
               em(ng-if='topic.severity') {{topic.severity}}
           td
+            span(ng-if='topic.listed === "always"') Always
+            span(ng-if='topic.listed === "has_hits"') If systems affected
+            span(ng-if='topic.listed === "never"') Never
+            span.icon-inline(ng-show='topic.hidden')
+              i.red.fa.fa-eye-slash.inline-left(tooltip='This topic is not published. Only internal users can see it. Use the actions column to publish this topic.')
+          td
             span.icon-inline(ng-show='topic.hidden', ng-click='hide(topic, false)')
               i.fa.fa-eye(tooltip='Publish this topic')
             span.icon-inline(ng-hide='topic.hidden', ng-click='hide(topic, true)')
@@ -37,7 +43,6 @@
                 i.fa.fa-pencil-square-o.pointer
             span.icon-inline
               i.fa.fa-remove(ng-click='delete(topic)', tooltip='Remove this topic')
-          td
             a.icon-inline(ng-click='move(topic, true)', ng-disabled='topic.priority === 0', tooltip='Move this topic higher in the priority list. This affects the order in which topics are presented to customers.')
               i.fa.fa-arrow-up
             a.icon-inline(ng-click='move(topic, false)', ng-disabled='topic.priority === topics.length - 1', tooltip='Move this topic lower in the priority list. This affects the order in which topics are presented to customers.')


### PR DESCRIPTION
https://trello.com/c/3aZu6llG/5-granular-control-over-which-topics-are-shown-in-the-topic-list

Backporting to have consistent topic admin interface across beta and stable.