### PR TITLE
[gulp] fix race condition where tag would end up on previous commit

### DIFF
--- a/gulp/tasks/release.js
+++ b/gulp/tasks/release.js
@@ -36,19 +36,22 @@ We want the release commits to not include any additional changes.
         cb = cb || function () {};
         global.isProd = true;
         global.isRelease = true;
-        runSequence(bump, 'release-tag', 'release-commit', cb);
+        runSequence(bump, 'release-commit', 'release-tag', cb);
     });
 }
 
 gulp.task('release-tag', function () {
     const version = priv.getVersion();
-    git.tag(version, `Release ${version}`);
+    git.tag(version, `Release TEST ${version}`, function (err) {
+        if (err) { throw err; }
+    });
 });
 
 gulp.task('release-commit', function () {
     const version = priv.getVersion();
     gulp.src(['./package.json', './bower.json'])
-        .pipe(git.commit(`Release ${version}`));
+        .pipe(git.commit(`Release ${version}`))
+        .on('end', cb);
 });
 
 gulp.task('release', ['releasepatch']);


### PR DESCRIPTION
This turns this
```
2017-05-15 08:14 Jozef Hartinger o Release 4.10.2
2017-05-11 20:30 Jozef Hartinger o <4.10.2> quickfix for #87
```

Into this
```
2017-05-15 08:14 Jozef Hartinger o <4.10.2> Release 4.10.2
2017-05-11 20:30 Jozef Hartinger o quickfix for #87
```

Which is what is desired. The runsequence was out of order, but also the gulp-git commit function wrapped in the pipe was not properly waiting for things to finish.
