### PR TITLE
Fixed side margin on Announcement Page + added header

### DIFF
--- a/app/js/states/announcements/announcements.jade
+++ b/app/js/states/announcements/announcements.jade
@@ -1,7 +1,9 @@
-div.page-standard.page-announcements.section-announcements
-  .row
-    .col-sm-12
-      h1.page-title(translate) Announcements
+.page-header
+    h1.page-title.pull-left
+      i.fa.fa-bullhorn &nbsp;
+      span(translate) Announcements
+
+.content-wrap
   .row(ng-if="canCreate")
     .col-sm-12
       label.full-width(translate) Show hidden


### PR DESCRIPTION
Fixed issue #119 for the announcements page.

The entitlements page will be fixed with that page's redesign.