### PR TITLE
planner - introduce plan-list (pagination, multiple lists on one page, ...)

### DIFF
--- a/app/js/api/maintenance.js
+++ b/app/js/api/maintenance.js
@@ -13,6 +13,7 @@ function Maintenance(
     AccountService,
     $window,
     DataUtils,
+    Events,
     $rootScope) {
 
     var root = InsightsConfig.apiRoot;
@@ -63,7 +64,7 @@ function Maintenance(
     api.updatePlan = function (planId, data) {
         return $http.put(root + 'maintenance/' + planId + AccountService.current(), data)
             .then(function () {
-                $rootScope.$broadcast('maintenance:planChanged', planId);
+                $rootScope.$broadcast(Events.planner.planChanged, planId);
             });
     };
 
@@ -73,7 +74,7 @@ function Maintenance(
             'maintenance/' +
             plan.maintenance_id +
             AccountService.current()).then(function () {
-                $rootScope.$broadcast('maintenance:planDeleted', plan.maintenance_id);
+                $rootScope.$broadcast(Events.planner.planDeleted, plan.maintenance_id);
             });
     };
 

--- a/app/js/components/maintenance/maintenanceCategorySelect/maintenanceCategorySelect.directive.js
+++ b/app/js/components/maintenance/maintenanceCategorySelect/maintenanceCategorySelect.directive.js
@@ -12,12 +12,12 @@ function maintenanceCategorySelectCtrl($rootScope,
                                        Events,
                                        MaintenanceService) {
 
-    const defaultCategory = 'notSuggested';
+    const defaultCategory = 'all';
 
     $scope.plans = MaintenanceService.plans;
 
     $scope.options = [{
-        id: 'notSuggested',
+        id: 'all',
         label: gettextCatalog.getString('All'),
         tag: null
     }, {

--- a/app/js/components/maintenance/maintenanceModal/maintenanceModal.directive.js
+++ b/app/js/components/maintenance/maintenanceModal/maintenanceModal.directive.js
@@ -34,7 +34,8 @@ function maintenanceModalCtrl($scope,
                               existingPlan,
                               Subset,
                               Rule,
-                              Group) {
+                              Group,
+                              Events) {
     $scope.MODES = MODES;
     $scope.tableEdit = true;
     $scope.selected = {};
@@ -113,7 +114,7 @@ function maintenanceModalCtrl($scope,
             $scope.tableParams = buildTableParams();
         }
 
-        $scope.$broadcast('maintenance:reload-table');
+        $scope.$broadcast(Events.planner.reloadTable);
     }
 
     $scope.$watchGroup(['selected.plan', 'newPlan', 'selected.group', 'selected.system'],

--- a/app/js/components/maintenance/maintenancePlan/maintenancePlan.directive.js
+++ b/app/js/components/maintenance/maintenancePlan/maintenancePlan.directive.js
@@ -248,7 +248,6 @@ function maintenancePlanCtrl(
 
         Maintenance.downloadPlaybook($scope.plan.maintenance_id)
         .then(function (response) {
-            $scope.scrollToPlan($scope.plan.maintenance_id);
             if (response.status === 200) {
                 const disposition = response.headers('content-disposition');
                 const filename = parseHeader(disposition).filename.replace(/"/g, '');
@@ -532,8 +531,11 @@ function maintenancePlan($document) {
                     return;
                 }
 
-                if ((active && !planHit && bodyHit) || (!active && planHit)) {
-                    scope.edit.toggle(scope.plan.maintenance_id);
+                if (!active && planHit) {
+                    scope.edit.activate(scope.plan.maintenance_id);
+                } else if (bodyHit && !isContainedBy($event, 'plan-wrap') &&
+                    Object.keys(scope.edit.items).length) {
+                    scope.edit.reset();
                 }
             }
 

--- a/app/js/components/maintenance/maintenancePlan/maintenancePlan.directive.js
+++ b/app/js/components/maintenance/maintenancePlan/maintenancePlan.directive.js
@@ -13,11 +13,98 @@ const swal = require('sweetalert2');
 const filter = require('lodash/filter');
 const flatMap = require('lodash/flatMap');
 const uniqBy = require('lodash/uniqBy');
+const moment = require('moment-timezone');
 
 const TAB_MAPPING = {
     undefined: 0,
     systems: 1,
     playbook: 2
+};
+
+//This handles the "basic" edit mode of a plan. Activated by clicking the hidden
+//'Click to edit this plan' button next to the plan name.
+function BasicEditHandler(plan, Maintenance, Utils, cb) {
+    this.active = false;
+    this.plan = plan;
+    this.Maintenance = Maintenance;
+    this.Utils = Utils;
+    this.cb = cb;
+}
+
+BasicEditHandler.prototype.init = function () {
+    if (this.plan) {
+        this.name = this.plan.name;
+        this.description = this.plan.description;
+        if (this.plan.start) {
+            this.start = moment(this.plan.start);
+            let d = this.start;
+
+            // we need to convert to Date (which possibly uses a different timezone)
+            // so that we can bind the input to it
+            this.time = new Date(d.year(), d.month(), d.day(), d.hour(), d.minute());
+            this.duration = Math.round((this.plan.end - this.plan.start) / (60 * 1000));
+        } else {
+            this.start = null;
+            this.time = null;
+            this.duration = null;
+        }
+    } else {
+        this.name = '';
+        this.description = '';
+        this.start = moment().startOf('day');
+        this.dateChanged(this.start);
+    }
+};
+
+BasicEditHandler.prototype.dateChanged = function (value) {
+    if (value && !this.time) {
+        this.time =
+            new Date(
+                this.start.year(),
+                this.start.month(),
+                this.start.day(),
+                22, 0);
+        this.duration = 60;
+        this.sync();
+    }
+};
+
+BasicEditHandler.prototype.sync = function () {
+    if (this.start && this.time) {
+        this.start.hours(this.time.getHours());
+        this.start.minutes(this.time.getMinutes());
+    }
+};
+
+BasicEditHandler.prototype.toggle = function () {
+    if (!this.active) {
+        this.init();
+    }
+
+    this.active = !this.active;
+};
+
+BasicEditHandler.prototype.getStart = function () {
+    if (this.start) {
+        return this.start.clone().toDate();
+    }
+
+    return null;
+};
+
+BasicEditHandler.prototype.getEnd = function () {
+    if (this.start) {
+        return this.start.clone().add(Math.max(this.duration, 1), 'm').toDate();
+    }
+
+    return null;
+};
+
+BasicEditHandler.prototype.save = function () {
+    this.sync();
+    if (this.cb) {
+        return this.cb(this.name, this.description, this.getStart(), this.getEnd(), this);
+    }
 };
 
 /**
@@ -34,6 +121,7 @@ function maintenancePlanCtrl(
     gettextCatalog,
     sweetAlert,
     DataUtils,
+    Events,
     Group,
     Maintenance,
     MaintenanceService,
@@ -54,7 +142,7 @@ function maintenancePlanCtrl(
 
     const CURRENT_GROUP_PREFIX = gettextCatalog.getString('Current Group');
 
-    $scope.editBasic = new $scope.BasicEditHandler(
+    $scope.editBasic = new BasicEditHandler(
         $scope.plan,
         Maintenance,
         Utils,
@@ -68,8 +156,8 @@ function maintenancePlanCtrl(
                 end: end
             }).then(function () {
                 handler.active = false;
-
-                if ($scope.plan.end !== end || $scope.plan.start !== start) {
+                if (!Utils.datesEqual($scope.plan.end, end) ||
+                    !Utils.datesEqual($scope.plan.start, start)) {
                     $scope.loadPlans(true).then(function () {
                         $scope.scrollToPlan($scope.plan.maintenance_id);
                     });
@@ -217,8 +305,8 @@ function maintenancePlanCtrl(
 
             $scope.update(data).then(function () {
                 assign($scope.plan, data);
-                $rootScope.$broadcast(
-                    'maintenance:planChanged', $scope.plan.maintenance_id);
+                $rootScope.$broadcast(Events.planner.planChanged,
+                    $scope.plan.maintenance_id);
             });
         }
 
@@ -236,7 +324,7 @@ function maintenancePlanCtrl(
         var data = {suggestion: Maintenance.SUGGESTION.ACCEPTED};
         $scope.update(data).then(function () {
             assign($scope.plan, data);
-            $rootScope.$broadcast('maintenance:planChanged', $scope.plan.maintenance_id);
+            $rootScope.$broadcast(Events.planner.planChanged, $scope.plan.maintenance_id);
             $scope.scrollToPlan($scope.plan.maintenance_id);
         });
     };
@@ -246,7 +334,7 @@ function maintenancePlanCtrl(
         $scope.update(data).then(function () {
             assign($scope.plan, data);
             $scope.plan.hidden = true;
-            $rootScope.$broadcast('maintenance:planChanged', $scope.plan.maintenance_id);
+            $rootScope.$broadcast(Events.planner.planChanged, $scope.plan.maintenance_id);
             if (!MaintenanceService.plans.suggested.length) {
                 $scope.setCategory('unscheduled');
             }

--- a/app/js/components/maintenance/maintenanceTable/maintenanceTable.controller.js
+++ b/app/js/components/maintenance/maintenanceTable/maintenanceTable.controller.js
@@ -15,7 +15,8 @@ function MaintenanceTable(
     Utils,
     MaintenanceService,
     sweetAlert,
-    gettextCatalog) {
+    gettextCatalog,
+    Events) {
 
     var ctrl = this;
 
@@ -77,7 +78,7 @@ function MaintenanceTable(
         evalActions();
     }
 
-    $scope.$on('maintenance:reload-table', reload);
+    $scope.$on(Events.planner.reloadTable, reload);
     $scope.$watchGroup(['item', 'edit'], reload);
 
     /*

--- a/app/js/components/maintenance/planList/planList.directive.js
+++ b/app/js/components/maintenance/planList/planList.directive.js
@@ -1,0 +1,69 @@
+'use strict';
+
+const componentsModule = require('../../');
+const findIndex = require('lodash/findIndex');
+const orderBy = require('lodash/orderBy');
+
+const DEFAULT_PAGE_SIZE = 8;
+
+/**
+ * @ngInject
+ */
+function planListCtrl($scope, $rootScope, Events, User, Utils) {
+    User.asyncCurrent(function () {
+        $scope.isInternal = User.current.is_internal;
+    });
+
+    function inherit (name) {
+        $scope.$parent.$watch(name, function (value) {
+            $scope[name] = value;
+        });
+    }
+
+    inherit('edit');
+    inherit('loadPlans');
+    inherit('scrollToPlan');
+
+    $scope.$watchCollection('plans', function () {
+        $scope.pager.reset();
+    });
+
+    $rootScope.$on(Events.planner.openPlan, function (event, id) {
+        // figure out which page the plan is on
+        const plans =
+            orderBy($scope.plans, ['start', 'maintenance_id'], ['desc', 'desc']);
+        const index = findIndex(plans, plan => plan.maintenance_id.toString() === id);
+
+        if (index === -1) {
+            return; // not in this list
+        }
+
+        const page = Math.floor(index / $scope.pager.perPage) + 1;
+
+        if (page !== $scope.pager.currentPage) {
+
+            // scroll to the given page
+            $scope.pager.currentPage = page;
+            $scope.pager.update();
+        }
+    });
+
+    $scope.pager = new Utils.Pager($scope.pageSize || DEFAULT_PAGE_SIZE);
+}
+
+function planList () {
+
+    return {
+        templateUrl: 'js/components/maintenance/planList/planList.html',
+        restrict: 'E',
+        controller: planListCtrl,
+        replace: true,
+        scope: {
+            plans: '<',
+            group: '<?',
+            pageSize: '<?'
+        }
+    };
+}
+
+componentsModule.directive('planList', planList);

--- a/app/js/components/maintenance/planList/planList.jade
+++ b/app/js/components/maintenance/planList/planList.jade
@@ -1,0 +1,16 @@
+.plans
+  .row(ng-if='!group')
+    maintenance-plan(ng-repeat='plan in plans | orderBy:"-maintenance_id" | limitTo:pager.perPage:pager.offset track by plan.maintenance_id')
+  .row(
+    ng-if='group',
+    ng-repeat='month in (plans | orderBy:["-start","-maintenance_id"] | limitTo:pager.perPage:pager.offset | groupPlans)')
+    .col-sm-12
+      h3 {{month[0].start | moment:'MMMM YYYY'}}
+    maintenance-plan(ng-repeat='plan in month | orderBy:"-start" track by plan.maintenance_id')
+  .row.row-short
+    pagination.pull-right.pagination-blue(
+      ng-if="plans.length > pager.perPage",
+      total-items="plans.length",
+      ng-model="pager.currentPage",
+      items-per-page="pager.perPage",
+      ng-change="pager.update()")

--- a/app/js/constants/events.js
+++ b/app/js/constants/events.js
@@ -41,7 +41,7 @@ let _EVENT_ROOTS = [{
     events: ['reset']
 }, {
     name: 'planner',
-    events: ['planChanged', 'planDeleted', 'reloadTable', 'plansLoaded']
+    events: ['planChanged', 'planDeleted', 'reloadTable', 'plansLoaded', 'openPlan']
 }];
 
 constantsModule.constant('Events', buildEvents(_EVENT_ROOTS));

--- a/app/js/constants/events.js
+++ b/app/js/constants/events.js
@@ -39,6 +39,9 @@ let _EVENT_ROOTS = [{
 }, {
     name: 'checkboxes',
     events: ['reset']
+}, {
+    name: 'planner',
+    events: ['planChanged', 'planDeleted', 'reloadTable']
 }];
 
 constantsModule.constant('Events', buildEvents(_EVENT_ROOTS));

--- a/app/js/constants/events.js
+++ b/app/js/constants/events.js
@@ -41,7 +41,7 @@ let _EVENT_ROOTS = [{
     events: ['reset']
 }, {
     name: 'planner',
-    events: ['planChanged', 'planDeleted', 'reloadTable']
+    events: ['planChanged', 'planDeleted', 'reloadTable', 'plansLoaded']
 }];
 
 constantsModule.constant('Events', buildEvents(_EVENT_ROOTS));

--- a/app/js/services/maintenance.service.js
+++ b/app/js/services/maintenance.service.js
@@ -30,7 +30,8 @@ function MaintenanceService(
     DataUtils,
     TopbarAlertsService,
     $state,
-    gettextCatalog) {
+    gettextCatalog,
+    Events) {
 
     var service = {};
     var plansDfd = false;
@@ -384,11 +385,11 @@ function MaintenanceService(
         return plan.name;
     };
 
-    $rootScope.$on('maintenance:planChanged', function () {
+    $rootScope.$on(Events.planner.planChanged, function () {
         service.plans.process();
     });
 
-    $rootScope.$on('maintenance:planDeleted', function (event, id) {
+    $rootScope.$on(Events.planner.planDeleted, function (event, id) {
         service.plans.remove(id);
     });
 

--- a/app/js/services/maintenance.service.js
+++ b/app/js/services/maintenance.service.js
@@ -235,7 +235,9 @@ function MaintenanceService(
         if (force || !plansDfd) {
             plansDfd = Maintenance.getMaintenancePlans().then(function (plans) {
                 service.plans.all = plans;
-                return service.plans.process();
+                return service.plans.process().then(function () {
+                    $rootScope.$broadcast(Events.planner.plansLoaded);
+                });
             });
         }
 

--- a/app/js/services/maintenance.service.js
+++ b/app/js/services/maintenance.service.js
@@ -253,7 +253,7 @@ function MaintenanceService(
             service.plans.overdue = [];
             service.plans.unscheduled = [];
             service.plans.suggested = [];
-            service.plans.notSuggested = [];
+            service.plans.scheduled = [];
             service.plans.all.forEach(function (plan) {
                 // filter out hidden plans
                 // TODO: this is what backend is supposed to do
@@ -275,10 +275,9 @@ function MaintenanceService(
                         }
                     }
 
-                    service.plans.notSuggested.push(plan);
+                    service.plans.scheduled.push(plan);
                 } else {
                     service.plans.unscheduled.push(plan);
-                    service.plans.notSuggested.push(plan);
                 }
             });
 

--- a/app/js/services/utils.service.js
+++ b/app/js/services/utils.service.js
@@ -355,6 +355,14 @@ function Utils($filter, $rootScope, Events) {
         return value;
     };
 
+    utils.datesEqual = function (d1, d2) {
+        if (d1 === d2) {
+            return true;
+        }
+
+        return new Date(d1).getTime() === new Date(d2).getTime();
+    };
+
     return utils;
 }
 

--- a/app/js/states/maintenance/maintenance.controller.js
+++ b/app/js/states/maintenance/maintenance.controller.js
@@ -7,7 +7,7 @@ var values = require('lodash/values');
 var moment = require('moment-timezone');
 var CATEGORY_PREFERENCE_KEY = 'maintenance_plan_category';
 
-const DEFAULT_CATEGORY = 'notSuggested';
+const DEFAULT_CATEGORY = 'all';
 
 // tracks which plans are expanded into the edit mode
 // This handles the mode activated by the first click on a plan.
@@ -74,6 +74,7 @@ EditToggleHandler.prototype.transition = function (id) {
  */
 function MaintenanceCtrl(
     $scope,
+    $timeout,
     Maintenance,
     Utils,
     $stateParams,
@@ -83,7 +84,8 @@ function MaintenanceCtrl(
     PermalinkService,
     $state,
     $rootScope,
-    SystemsService) {
+    SystemsService,
+    Events) {
 
     $scope.isDefined = angular.isDefined;
     $scope.loader = new Utils.Loader();
@@ -114,11 +116,16 @@ function MaintenanceCtrl(
         });
     });
 
-    $scope.scrollToPlan = function (id, cat) {
-        let category = cat || MaintenanceService.plans.findCategory(id);
-        $scope.setCategory(category);
-        $scope.edit.activate(id);
-        PermalinkService.scroll('maintenance-plan-' + id);
+    $scope.scrollToPlan = function (id) {
+        if ($scope.category !== 'all') {
+            $scope.setCategory('all');
+        }
+
+        $timeout(function () {
+            $scope.edit.activate(id);
+            $rootScope.$broadcast(Events.planner.openPlan, id);
+            PermalinkService.scroll('maintenance-plan-' + id, 50);
+        });
     };
 
     $scope.redrawPlans = function () {

--- a/app/js/states/maintenance/maintenance.controller.js
+++ b/app/js/states/maintenance/maintenance.controller.js
@@ -69,92 +69,6 @@ EditToggleHandler.prototype.transition = function (id) {
     });
 };
 
-//This handles the "basic" edit mode of a plan. Activated by clicking the hidden
-//'Click to edit this plan' button next to the plan name.
-function BasicEditHandler(plan, Maintenance, Utils, cb) {
-    this.active = false;
-    this.plan = plan;
-    this.Maintenance = Maintenance;
-    this.Utils = Utils;
-    this.cb = cb;
-}
-
-BasicEditHandler.prototype.init = function () {
-    if (this.plan) {
-        this.name = this.plan.name;
-        this.description = this.plan.description;
-        if (this.plan.start) {
-            this.start = moment(this.plan.start);
-            let d = this.start;
-
-            // we need to convert to Date (which possibly uses a different timezone)
-            // so that we can bind the input to it
-            this.time = new Date(d.year(), d.month(), d.day(), d.hour(), d.minute());
-            this.duration = Math.round((this.plan.end - this.plan.start) / (60 * 1000));
-        } else {
-            this.start = null;
-            this.time = null;
-            this.duration = null;
-        }
-    } else {
-        this.name = '';
-        this.description = '';
-        this.start = moment().startOf('day');
-        this.dateChanged(this.start);
-    }
-};
-
-BasicEditHandler.prototype.dateChanged = function (value) {
-    if (value && !this.time) {
-        this.time =
-            new Date(
-                this.start.year(),
-                this.start.month(),
-                this.start.day(),
-                22, 0);
-        this.duration = 60;
-        this.sync();
-    }
-};
-
-BasicEditHandler.prototype.sync = function () {
-    if (this.start && this.time) {
-        this.start.hours(this.time.getHours());
-        this.start.minutes(this.time.getMinutes());
-    }
-};
-
-BasicEditHandler.prototype.toggle = function () {
-    if (!this.active) {
-        this.init();
-    }
-
-    this.active = !this.active;
-};
-
-BasicEditHandler.prototype.getStart = function () {
-    if (this.start) {
-        return this.start.clone().toDate();
-    }
-
-    return null;
-};
-
-BasicEditHandler.prototype.getEnd = function () {
-    if (this.start) {
-        return this.start.clone().add(Math.max(this.duration, 1), 'm').toDate();
-    }
-
-    return null;
-};
-
-BasicEditHandler.prototype.save = function () {
-    this.sync();
-    if (this.cb) {
-        return this.cb(this.name, this.description, this.getStart(), this.getEnd(), this);
-    }
-};
-
 /**
  * @ngInject
  */
@@ -171,7 +85,6 @@ function MaintenanceCtrl(
     $rootScope,
     SystemsService) {
 
-    $scope.BasicEditHandler = BasicEditHandler;
     $scope.isDefined = angular.isDefined;
     $scope.loader = new Utils.Loader();
     $scope.MaintenanceService = MaintenanceService;

--- a/app/js/states/maintenance/maintenance.jade
+++ b/app/js/states/maintenance/maintenance.jade
@@ -32,17 +32,21 @@
             span(translate) Loading plans…
       .rha-notifications
       div(ng-if='!loading')
-        .row(ng-if="!shownPlans.length")
+        .row(ng-if="!plans[category].length")
           .text-center
             h4(translate) No plans
-        .row(ng-if="category === 'future' || category === 'past'", ng-repeat="plansPerMonth in shownPlansByMonth")
-          .col-sm-12
-            h3 {{plansPerMonth[0].start | moment:'MMMM YYYY'}}
-          maintenance-plan(
-            ng-repeat="plan in plansPerMonth | searchMaintenancePlans: searchTerm track by plan.maintenance_id")
-        .row(ng-if="category === 'unscheduled' || category === 'suggested'")
-          maintenance-plan(
-            ng-repeat="plan in shownPlans | searchMaintenancePlans: searchTerm | orderBy:'-maintenance_id' track by plan.maintenance_id")
-        .row(ng-if="category === 'notSuggested'")
-          maintenance-plan(
-            ng-repeat="plan in shownPlans | searchMaintenancePlans: searchTerm | orderBy:['suggestion !== null', '-start', '-maintenance_id'] track by plan.maintenance_id")
+
+        plan-list(ng-if="category === 'unscheduled'", plans='plans.unscheduled | searchMaintenancePlans: searchTerm', page-size='8')
+        plan-list(ng-if="category === 'suggested'", plans='plans.suggested | searchMaintenancePlans: searchTerm', page-size='8')
+        plan-list(ng-if="category === 'past'", plans='plans.past | searchMaintenancePlans: searchTerm', group='true', page-size='6')
+        plan-list(ng-if="category === 'future'", plans='plans.future | searchMaintenancePlans: searchTerm', group='true', page-size='6')
+
+        span(ng-if="category === 'all'")
+          h2(translate, ng-if='plans.suggested.length') Suggested Plans
+          plan-list(plans='plans.suggested | searchMaintenancePlans: searchTerm', page-size='2')
+
+          h2(translate, ng-if='plans.unscheduled.length') Plans
+          plan-list(plans='plans.unscheduled | searchMaintenancePlans: searchTerm', page-size='6')
+
+          h2(translate, ng-if='plans.scheduled.length') Scheduled Plans
+          plan-list(plans='plans.scheduled | searchMaintenancePlans: searchTerm', group='true', page-size='4')

--- a/test/unit/states/maintenance/category_spec.js
+++ b/test/unit/states/maintenance/category_spec.js
@@ -119,7 +119,7 @@ describe('MaintenanceController', function () {
     it('opens "all" category by default', function () {
         initCtrl();
         scope.$digest();
-        scope.category.should.equal('notSuggested');
+        scope.category.should.equal('all');
     });
 
     it('switches to different category', function () {
@@ -130,50 +130,6 @@ describe('MaintenanceController', function () {
         scope.category.should.equal('future');
 
         scope.setCategory('past');
-        scope.$digest();
-        scope.category.should.equal('past');
-    });
-
-    it('switches to "suggested" on new suggestion creation', function (done) {
-        initCtrl();
-        scope.setCategory('future');
-        scope.$digest();
-        scope.category.should.equal('future');
-
-        // mock
-        api.createPlan = mockAsPromised({
-            data: {
-                id: 346
-            }
-        });
-        api.getMaintenancePlan = mockAsPromised({
-            data: {
-                maintenance_id: 346,
-                suggestion: 'proposed'
-            }
-        });
-
-        scope.newSuggestion().then(function () {
-            scope.category.should.equal('suggested');
-            done();
-        });
-
-        scope.$digest();
-    });
-
-    it('opens "past" if a state param for a specific plan is set', function () {
-        api.getMaintenancePlans = mockAsPromised([
-            {
-                maintenance_id: 1,
-                suggestion: 'proposed'
-            }, {
-                maintenance_id: 2,
-                end: new Date(2010, 1, 1)
-            }
-        ]);
-        params.maintenance_id = 2;
-
-        initCtrl();
         scope.$digest();
         scope.category.should.equal('past');
     });


### PR DESCRIPTION
Adds mainly pagination, addresses minor bugs. On the default page (no category filter applied), unscheduled, scheduled and suggested plans use their own pagination. That ensures that the plan scheduled for tomorrow won't be buried on page 10 after dozens of unscheduled plans.

The lists have the ability to scroll to the right page in order to expand a given plan. `openPlan` event is used for this.

https://trello.com/c/7RA1ljVR/13-pagination-on-plans
https://trello.com/c/YULef0gU/121-add-nofilter-view-all-plans

Depends on https://github.com/RedHatInsights/insights-frontend/pull/164