### PR TITLE
Replaces getting started string literal with config property

### DIFF
--- a/app/js/components/overview/widgets/goals/goalsLite.directive.js
+++ b/app/js/components/overview/widgets/goals/goalsLite.directive.js
@@ -12,6 +12,7 @@ function GoalsLiteDirectiveCtrl(
     System,
     Evaluation,
     HttpHeaders,
+    InsightsConfig,
     Report,
     Stats) {
 
@@ -19,6 +20,8 @@ function GoalsLiteDirectiveCtrl(
 
     // Gauge requires a function
     $scope.getMaxFreeSystems = function () { return $scope.maxFreeSystems; };
+
+    $scope.gettingStartedLink = InsightsConfig.gettingStartedLink;
 
     priv.getSevCount = function (sev, data) {
         return reduce(data, function (sum, obj) {

--- a/app/js/components/overview/widgets/goals/goalsLite.jade
+++ b/app/js/components/overview/widgets/goals/goalsLite.jade
@@ -42,4 +42,4 @@
       .col-sm-12.text-center
         h3 You have no systems registered. Take full advantage of Red Hat Insights by&nbsp;
           // need to make this link clickable
-          a.link(translate, href="https://access.redhat.com/products/red-hat-insights#getstarted", target="_blank") registering systems.
+          a.link(translate, href="{{gettingStartedLink}}", target="_blank") registering systems.

--- a/app/js/components/system/addSystemModal/addSystemModal.controller.js
+++ b/app/js/components/system/addSystemModal/addSystemModal.controller.js
@@ -5,10 +5,12 @@ var componentsModule = require('../../');
 /**
  * @ngInject
  */
-function AddSystemModalCtrl($scope, $modalInstance) {
+function AddSystemModalCtrl($scope, $modalInstance, InsightsConfig) {
     $scope.close = function () {
         $modalInstance.dismiss('close');
     };
+
+    $scope.gettingStartedLink = InsightsConfig.gettingStartedLink;
 }
 
 componentsModule.controller('AddSystemModalCtrl', AddSystemModalCtrl);

--- a/app/js/components/system/addSystemModal/addSystemModal.jade
+++ b/app/js/components/system/addSystemModal/addSystemModal.jade
@@ -23,7 +23,7 @@
       h2.section-header(translate) Advanced configuration
       p(translate)
         | For more advanced configuration see the 
-        a(href='https://access.redhat.com/products/red-hat-insights#getstarted', target='_blank', ng-click="close()", translate) getting started guide
+        a(href='{{gettingStartedLink}}', target='_blank', ng-click="close()", translate) getting started guide
         | .
 
 

--- a/app/js/components/topbar/topbar.directive.js
+++ b/app/js/components/topbar/topbar.directive.js
@@ -15,6 +15,8 @@ const DISABLED_STATES = [
  * @ngInject
  */
 function TopbarCtrl($scope, InsightsConfig, $state) {
+    $scope.gettingStartedLink = InsightsConfig.gettingStartedLink;
+
     $scope.isPortal = InsightsConfig.isPortal;
 
     function checkState () {

--- a/app/js/components/topbar/topbar.jade
+++ b/app/js/components/topbar/topbar.jade
@@ -17,7 +17,7 @@
           i.inline-left.fa.fa-question-circle
         ul.dropdown-menu
           li
-            a(href='https://access.redhat.com/products/red-hat-insights#getstarted', target='_blank', translate) Getting Started
+            a(href='{{gettingStartedLink}}', target='_blank', translate) Getting Started
           li
             a(href='https://access.redhat.com/documentation/en/red-hat-insights/', target='_blank', translate) Product Documentation
           li

--- a/app/js/portal/config.js
+++ b/app/js/portal/config.js
@@ -30,6 +30,8 @@ function Config(cfpLoadingBarProvider, InsightsConfigProvider) {
     let anHour = (60 * 60 * 1000);
     InsightsConfigProvider.setAutoRefresh(anHour);
     InsightsConfigProvider.setPortal(true);
+    InsightsConfigProvider.setGettingStartedLink(
+        'https://access.redhat.com/products/red-hat-insights#getstarted');
 }
 
 module.exports = Config;

--- a/app/js/states/info/info.controller.js
+++ b/app/js/states/info/info.controller.js
@@ -5,7 +5,9 @@ var statesModule = require('../');
 /**
  * @ngInject
  */
-function InfoCtrl(PermalinkService) {
+function InfoCtrl($scope, InsightsConfig, PermalinkService) {
+    $scope.gettingStartedLink = InsightsConfig.gettingStartedLink;
+
     PermalinkService.scroll();
 }
 

--- a/app/js/states/info/info.jade
+++ b/app/js/states/info/info.jade
@@ -99,5 +99,5 @@
             .row
               .col-xs-12.col-sm-7.col-md-8.vcenter
                 a.btn.btn-app.cta-link.cta-link-sm.cta-link-white.info-links(href="static/misc/datasheet.pdf", target="_blank", translate) Datasheet
-                a.btn.btn-app.cta-link.cta-link-sm.cta-link-white.info-links(href='https://access.redhat.com/products/red-hat-insights#getstarted', translate) Getting started with Red Hat Insights
+                a.btn.btn-app.cta-link.cta-link-sm.cta-link-white.info-links(href='{{gettingStartedLink}}', translate) Getting started with Red Hat Insights
                 a.btn.btn-app.cta-link.cta-link-sm.cta-link-white.info-links(ui-sref='login', translate) Log in to Red Hat Insights

--- a/app/js/states/security/security.controller.js
+++ b/app/js/states/security/security.controller.js
@@ -5,8 +5,8 @@ var statesModule = require('../');
 /**
  * @ngInject
  */
-function GettingStartedCtrl() {
-
+function GettingStartedCtrl($scope, InsightsConfig) {
+    $scope.gettingStartedLink = InsightsConfig.gettingStartedLink;
 }
 
 statesModule.controller('SecurityCtrl', GettingStartedCtrl);

--- a/app/js/states/security/security.jade
+++ b/app/js/states/security/security.jade
@@ -56,5 +56,5 @@
       .col-md-12
         section.section
           h3(translate) Additional Resources
-          a.btn.btn-app.cta-link.cta-link-sm.cta-link-white.info-links(href='https://access.redhat.com/products/red-hat-insights#getstarted', translate) Getting started with Red Hat Insights
+          a.btn.btn-app.cta-link.cta-link-sm.cta-link-white.info-links(href='{{gettingStartedLink}}', translate) Getting started with Red Hat Insights
           a.btn.btn-app.cta-link.cta-link-sm.cta-link-white.info-links(ui-sref='login', translate) Log in to Red Hat Insights

--- a/app/js/states/splash/splash.controller.js
+++ b/app/js/states/splash/splash.controller.js
@@ -5,7 +5,9 @@ var statesModule = require('../');
 /**
  * @ngInject
  */
-function SplashCtrl($scope, $state) {
+function SplashCtrl($scope, $state, InsightsConfig) {
+    $scope.gettingStartedLink = InsightsConfig.gettingStartedLink;
+
     $scope.logged_in = window.LOGGED_IN;
     if (window.LOGGED_IN && $state.current && $state.current.bounceLoggedin) {
         $state.go('app.initial', {}, {

--- a/app/js/states/splash/splash.jade
+++ b/app/js/states/splash/splash.jade
@@ -6,7 +6,7 @@
         .strapline(translate) Take the guesswork out of infrastructure optimization with Red Hat Insights proactive analytics and real-time intelligence.
     .row
       .col-sm-12.text-center
-        a.btn.btn-app(href='https://access.redhat.com/products/red-hat-insights#getstarted', translate) Getting started guide
+        a.btn.btn-app(href='{{gettingStartedLink}}', translate) Getting started guide
         span.strapline.btn-seperator(translate) or
         a.btn.btn-app(ui-sref='app.overview', translate) Go to the application
 
@@ -41,7 +41,7 @@
   .container.text-center
     h2.section-header(translate) Start proactively finding and fixing infrastructure risks today
     h2(translate) Your current subscription provides a free 30-day evaluation
-    a.btn.btn-app(href='https://access.redhat.com/products/red-hat-insights#getstarted', translate) TRY IT
+    a.btn.btn-app(href='{{gettingStartedLink}}', translate) TRY IT
 
 .core-values.band.band-gray-light
   .container


### PR DESCRIPTION
This enables Satellite to use an internal Insights getting started page.

#262 