### PR TITLE
Fixes/default sort indication

### DIFF
--- a/app/js/components/topics/topicRuleList/topicRuleList.directive.js
+++ b/app/js/components/topics/topicRuleList/topicRuleList.directive.js
@@ -21,7 +21,7 @@ function topicRuleListCtrl ($filter,
     $scope.listTypes = ListTypeService.types();
     $scope.getListType = ListTypeService.getType;
     $scope.sorter = new Utils.Sorter({
-        predicate:['acked', 'hitCount === 0', '-severityNum', '-hitCount'],
+        predicate: ['acked', 'hitCount === 0', '-severityNum', '-hitCount'],
         reverse: false},
         order);
 

--- a/app/js/services/utils.service.js
+++ b/app/js/services/utils.service.js
@@ -258,8 +258,8 @@ function Utils($filter, $rootScope, Events) {
     };
 
     utils.Sorter.prototype.sort = function (name) {
+        this.reverse = (this.predicate === name) ? !this.reverse : false;
         this.predicate = name;
-        this.reverse = !this.reverse;
         if (this.cb) {
             this.cb();
         }

--- a/app/js/states/inventory/inventory.controller.js
+++ b/app/js/states/inventory/inventory.controller.js
@@ -71,8 +71,8 @@ function InventoryCtrl(
     $scope.loading = InventoryService.loading;
     $scope.reloading = false;
 
-    $scope.sorter = new Utils.Sorter(false, order);
-    $scope.sorter.predicate = 'toString';
+    $scope.predicate = $location.search().sort_field || 'toString';
+    $scope.reverse = $location.search().sort_dir === 'DESC';
 
     $scope.allSelected = false;
     $scope.reallyAllSelected = false;
@@ -299,14 +299,13 @@ function InventoryCtrl(
     function order() {
         $scope.systems = $filter('orderBy')($scope.systems,
             ['_type',
-            ($scope.sorter.reverse ?
-                '-' + $scope.sorter.predicate :
-                $scope.sorter.predicate)]);
+            ($scope.reverse ?
+                '-' + $scope.predicate :
+                $scope.predicate)]);
     }
 
     $scope.sort = function (column) {
         $scope.loading = true;
-        $scope.predicate = column;
 
         // just changing the sort direction
         if (column === InventoryService.getSortField()) {
@@ -317,6 +316,7 @@ function InventoryCtrl(
             InventoryService.setSortField(column);
             InventoryService.setSortDirection('ASC');
             $scope.reverse = false;
+            $scope.predicate = column;
 
             // special case where we are sorting by timestamp but visually
             // showing timeago
@@ -327,8 +327,6 @@ function InventoryCtrl(
 
         // if we have the full inventory list then use local sorting
         if ($scope.systems.length === InventoryService.getTotal()) {
-            $scope.sorter.predicate = column;
-            $scope.sorter.reverse = $scope.reverse;
             order();
             $scope.loading = false;
         }

--- a/test/unit/components/maintenanceTable_spec.js
+++ b/test/unit/components/maintenanceTable_spec.js
@@ -92,7 +92,6 @@ describe('MaintenanceTable', function () {
 
     it('sorts items by id', function () {
         ctrl.sorter.sort('id');
-        ctrl.sorter.sort('id');
         ctrl.data[0].id.should.equal(1);
         ctrl.data[0].display.should.equal('delta');
         ctrl.data[1].id.should.equal(2);
@@ -102,8 +101,9 @@ describe('MaintenanceTable', function () {
 
     it('splits data into pages', function () {
         ctrl.pager.perPage = 4;
+        ctrl.sorter.sort('id');
         ctrl.sorter.sort('id'); // descending
-
+        
         // first page: 7, 6, 5, 4
         ctrl.pager.currentPage.should.equal(1);
         ctrl.data.length.should.equal(4);


### PR DESCRIPTION
Inventory and topics were not properly applying the sort-indicator class on initial page load.

Opened new issue to refactor inventory sorting to use utils sorter #309 in order to be more consistent with the rest of the app.