### PR TITLE
Gray font color too light

### DIFF
--- a/app/styles/base.scss
+++ b/app/styles/base.scss
@@ -109,6 +109,7 @@ $define-fa: true !default;
 @import 'components/dropdown';
 @import 'components/materials';
 @import 'components/newRules';
+@import 'components/webhooks';
 
 @import 'components/splash/landing-page';
 @import 'components/prod-filters-link';

--- a/app/styles/components/_webhooks.scss
+++ b/app/styles/components/_webhooks.scss
@@ -1,5 +1,3 @@
 .webhooks {
-  .gray {
-    color: $gray-cloud;
-  }
+  .gray { color: $gray-cloud; }
 }

--- a/app/styles/components/_webhooks.scss
+++ b/app/styles/components/_webhooks.scss
@@ -1,0 +1,5 @@
+.webhooks {
+  .gray {
+    color: $gray-cloud;
+  }
+}

--- a/app/styles/elements/_typography.scss
+++ b/app/styles/elements/_typography.scss
@@ -27,10 +27,6 @@ h2.headline {
   color: #31c7ff;
 }
 
-.gray {
-  color: $gray;
-}
-
 .large-text {
   @include font-size(16px);
 }

--- a/app/styles/includes/_vars.scss
+++ b/app/styles/includes/_vars.scss
@@ -31,6 +31,7 @@ $blue: #2097e6;
 $red: #c00;
 $blue_dark: #0085cf;
 $gray-light: #f2f5f7;
+$gray-cloud: #d9d9d9;
 $green: #46b631;
 $orange: #f0ab00;
 $gray-med: #6e6e6e;


### PR DESCRIPTION
Looks like we have a lot of .gray styling already. As far as I can tell, the addition of .gray to _typography.scss only applies to webhooks, so I just created a new file for that and declared a new color name. 

Fixes #312 