### PR TITLE
fix rule hit search #327

### DIFF
--- a/app/js/components/actions/actionsRule/actionsRule.controller.js
+++ b/app/js/components/actions/actionsRule/actionsRule.controller.js
@@ -134,8 +134,12 @@ function ActionsRuleCtrl(
      *
      * @param paginate gets all ruleSystems if set to false
      */
-    function getData(paginate) {
+    function getData(paginate = true, resetPager = true) {
         $scope.loadingSystems = true;
+
+        if (resetPager) {
+            $scope.pager.reset();
+        }
 
         return RhaTelemetryActionsService.getActionsRulePage(paginate, $scope.pager)
         .then(function () {
@@ -149,7 +153,7 @@ function ActionsRuleCtrl(
         $scope.pager.update();
         $location.search('page', $scope.pager.currentPage);
         $location.search('pageSize', $scope.pager.perPage);
-        getData(true)
+        getData(true, false)
         .then(function () {
             if ($scope.reallyAllSelected) {
                 $scope.checkboxes.checkboxChecked(true, $scope.ruleSystems);
@@ -331,7 +335,7 @@ function ActionsRuleCtrl(
     $scope.reallySelectAll = function () {
         $scope.allSelected = true;
         $scope.reallyAllSelected = true;
-        getData(false);
+        getData(false, false);
     };
 
     /*

--- a/app/js/components/actions/actionsRule/actionsRule.jade
+++ b/app/js/components/actions/actionsRule/actionsRule.jade
@@ -18,7 +18,7 @@
       article(ng-bind-html='ruleDetails.generic_html | trust_html')
 
   table-filters
-    search-box(placeholder="{{'Search rules' | translate}}", on-search='search.doFilter(model)')
+    search-box(placeholder="{{'Find a system' | translate}}", on-search='search(model)')
     check-in-select
 
   section.content
@@ -46,8 +46,8 @@
               show-tooltip='false')
 
       .table-header-title
-        h3.system-count(translate, translate-n='{{totalRuleSystems}}', translate-plural='{{$count}} Impacted Systems', ng-if='ruleDetails.type !== "osp"') 1 Impacted System
-        h3.system-count(translate, translate-n='{{totalRuleSystems}}', translate-plural='{{$count}} Impacted Deployments', ng-if='ruleDetails.type === "osp"') 1 Impacted Deployment
+        h3.system-count(translate, translate-n='totalRuleSystems', translate-plural='{{$count}} Impacted Systems', ng-if='ruleDetails.type !== "osp"') 1 Impacted System
+        h3.system-count(translate, translate-n='totalRuleSystems', translate-plural='{{$count}} Impacted Deployments', ng-if='ruleDetails.type === "osp"') 1 Impacted Deployment
         small.light(ng-if='checkboxes.totalChecked', translate) &nbsp; ({{numberOfSelected()}} Selected
           span(ng-show='allSelected && pager.perPage < totalRuleSystems') .
             a(ng-show='!reallyAllSelected', ng-click='reallySelectAll()') &nbsp;Select All Systems.
@@ -55,26 +55,27 @@
           span )
       list-type(ng-hide='hideListSwitch')
 
-    .card-table-header(ng-show='getListType() === listTypes.card')
-      md-checkbox.md-accent.md-hue-1(
-        aria-label="Select All Systems Checkbox",
-        tooltip="{{'Select All' | translate}}",
-        tooltip-trigger='mouseenter',
-        tooltip-append-to-body='true',
-        tooltip-placement='top',
-        type="checkbox",
-        md-indeterminate="checkboxes.indeterminate",
-        ng-model='checkboxes.checked',
-        ng-change='selectAll(); checkboxes.checkboxChecked(checkboxes.checked, getSelectableSystems())')
-      label.type(translate, ng-click="sort('system_type_id')") &nbsp; Type
-      strong.hostname(translate, ng-click="sort('toString')") Name &nbsp;
-      strong.action-count(translate, ng-click="sort('report_count')") Action Count
+    span(ng-show='getListType() === listTypes.card')
+      .card-table-header
+        md-checkbox.md-accent.md-hue-1(
+          aria-label="Select All Systems Checkbox",
+          tooltip="{{'Select All' | translate}}",
+          tooltip-trigger='mouseenter',
+          tooltip-append-to-body='true',
+          tooltip-placement='top',
+          type="checkbox",
+          md-indeterminate="checkboxes.indeterminate",
+          ng-model='checkboxes.checked',
+          ng-change='selectAll(); checkboxes.checkboxChecked(checkboxes.checked, getSelectableSystems())')
+        label.type(translate, ng-click="sort('system_type_id')") &nbsp; Type
+        strong.hostname(translate, ng-click="sort('toString')") Name &nbsp;
+        strong.action-count(translate, ng-click="sort('report_count')") Action Count
 
-    system-card(ng-repeat='system in ruleSystems',
-      system='system',
-      rule='ruleDetails',
-      checkboxes='checkboxes',
-      ng-show='getListType() === listTypes.card && !loadingSystems')
+    .system-cards.card-list(ng-show='getListType() === listTypes.card && !loadingSystems')
+      system-card.ng-animate-enabled(ng-repeat='system in ruleSystems track by system.system_id',
+        system='system',
+        rule='ruleDetails',
+        checkboxes='checkboxes')
 
     table(ng-show='getListType() === listTypes.table')
       thead
@@ -91,11 +92,11 @@
           th.sortable(ng-class="predicate | sortClass:'toString':reverse", ng-click="sort('toString')", translate) Name
           th.min.sortable(ng-class="predicate | sortClass:'last_check_in':!reverse", ng-click="sort('last_check_in')", translate) Reported
 
-      tbody
+      tbody(ng-hide='loadingSystems')
         tr(ng-click='checkboxes.rowClick($event, system.system_id)',
            ng-mousedown='checkboxes.rowClick($event, system.system_id)',
            ng-class="{'stale': !system.isCheckingIn}",
-           ng-repeat='system in ruleSystems',
+           ng-repeat='system in ruleSystems track by system.system_id',
            data-id="{{system.system_id}}")
           td.min
             md-checkbox.md-accent.md-hue-1.md-checkbox-list(
@@ -118,7 +119,6 @@
       items-per-page="pager.perPage",
       ng-change="paginate()")
 
-  .margin-top(ng-show='loading')
+  .margin-top(ng-show='loading || loadingSystems')
     .text-center
       .spinner.spinner-lg
-        

--- a/app/js/components/card/systemCard/systemCard.jade
+++ b/app/js/components/card/systemCard/systemCard.jade
@@ -1,4 +1,4 @@
-.system-card(ng-class="{'stale': !system.isCheckingIn}", ng-if='!loading',)
+.system-card(ng-class="{'stale': !system.isCheckingIn}")
   card.card-rule-summary(expandable init-collapsed='initCollapsed' on-toggle='toggleContent(ctx)')
     card-header-expandable.gray
       i.fa.spinner-xs.spinner(ng-if='loading')

--- a/app/js/services/actions.service.js
+++ b/app/js/services/actions.service.js
@@ -426,28 +426,10 @@ function ActionsService(
      * @param pager contains the current page and page size of the page being pulled
      */
     pub.getActionsRulePage = function (paginate, pager) {
-        let systemDeferred;
 
-        // if we already have all of the systems affected use vars.allSystems
-        if (vars.allSystems === null ||
-            vars.allSystems.length === vars.totalRuleSystems) {
-            systemDeferred = pub.buildSystemsDeferred(paginate, pager)
-                .then(function (results) {
-                    return priv.populateAffectedHosts(results);
-                });
-        }
-        else {
-            systemDeferred = $q.resolve(true);
-
-            vars.ruleSystems = vars.allSystems.slice(
-                                        ((pager.currentPage - 1) * pager.perPage),
-                                        priv.getPageEnd(
-                                            vars.allSystems,
-                                            pager.currentPage - 1,
-                                            pager.perPage));
-        }
-
-        return systemDeferred;
+        // TODO: this may be cached if we have all results fetched
+        return pub.buildSystemsDeferred(paginate, pager)
+        .then(priv.populateAffectedHosts);
     };
 
     /**


### PR DESCRIPTION
https://github.com/RedHatInsights/insights-frontend/issues/327
https://github.com/RedHatInsights/insights-frontend/issues/334

I had to wrap listType=card components in a span - otherwise the combination of ng-repeate and transclude was removing the table from the DOM even though there was not reason for that.