### PR TITLE
Fixes summary column on view policy page

### DIFF
--- a/app/js/components/primary-nav/primary-nav.jade
+++ b/app/js/components/primary-nav/primary-nav.jade
@@ -21,7 +21,7 @@ md-sidenav.primary-nav(md-component-id="left")
           i.fa.fa-wrench
           span.text(translate) Planner
       li(ng-if='canSeePolicies')
-        a(ui-sref='app.list-policies', ng-class='{current: includes(states.policies, state.current.name)}')
+        a(ui-sref='app.list-policies', ui-sref-active='current', md-ink-ripple, ng-class='{current: includes(states.policies, state.current.name)}')
           i.fa.fa-gavel
           span.text(translate) Policies
       li

--- a/app/js/states/policies/controllers/view.policy.controller.js
+++ b/app/js/states/policies/controllers/view.policy.controller.js
@@ -17,6 +17,7 @@ function ViewPolicyCtrl($filter,
     const PASSED = gettextCatalog.getString('passed');
     const FAILED = gettextCatalog.getString('failed');
     const ERRORED = gettextCatalog.getString('errored');
+    const UNKNOWN = gettextCatalog.getString('unknown');
 
     $scope.loading = true;
     $scope.pager = new Utils.Pager();
@@ -114,6 +115,8 @@ function ViewPolicyCtrl($filter,
             return FAILED;
         } else if (resource.checks_error > 0) {
             return ERRORED;
+        } else {
+            return UNKNOWN;
         }
     }
 

--- a/app/js/states/policies/views/view-policy.jade
+++ b/app/js/states/policies/views/view-policy.jade
@@ -27,7 +27,9 @@
             tr(ng-repeat="resource in policy.resources | orderBy: sorter.predicate : sorter.reverse")
               td.nowrap
                 a(ng-click='showSystem(resource.system_id)') {{resource.system.toString}}
-              td.nowrap(ng-class="resource.status", translate) Checks
+              td.nowrap(ng-class="resource.status", translate, translate-n='{{resource.checks_pass}}', translate-plural='{{$count}} Checks', ng-if="resource.checks_pass !== 0") {{resource.checks_pass}} Check
+                span &nbsp;{{resource.status}}
+              td.nowrap(ng-class="resource.status", translate, ng-if="resource.checks_pass === 0") Checks
                 span &nbsp;{{resource.status}}
 
     .row.row-short(ng-show='policy === null && !loading')

--- a/app/styles/includes/_mixins.scss
+++ b/app/styles/includes/_mixins.scss
@@ -37,6 +37,9 @@
   @if $state == errored {
     @include policyState-Styles('yellow', '\f071');
   }
+  @if $state == unknown {
+    @include policyState-Styles('unknown', '\f059');
+  }
 }
 
 @mixin policyState-Styles($color, $icon){

--- a/app/styles/includes/_vars.scss
+++ b/app/styles/includes/_vars.scss
@@ -40,7 +40,11 @@ $stateColors: (
 
   f-green: #399130,
   bs-green: #399130,
-  bg-green: #E6F2E6
+  bg-green: #E6F2E6,
+
+  f-unknown: #4c4c4c,
+  bs-unknown: #4c4c4c,
+  bg-unknown: #f9f9f9
 );
 
 // Brand Specific

--- a/app/styles/page-templates/_policies.scss
+++ b/app/styles/page-templates/_policies.scss
@@ -1,6 +1,7 @@
 .passed { @include policyState('passed'); }
 .errored { @include policyState('errored'); }
 .failed { @include policyState('failed'); }
+.unknown { @include policyState('unknown'); }
 
 .t-col-sm{
   width: 20%;


### PR DESCRIPTION
The view policy summary column was missing check counts and had some table cells that were blank. The blank cells are a result of incorrect counts being returned from the api. Ryan added a check in there to handle that issue.