### PR TITLE
Added esc navigation to policies and webhooks

### DIFF
--- a/app/js/states/config/webhook-edit.controller.js
+++ b/app/js/states/config/webhook-edit.controller.js
@@ -160,6 +160,14 @@ function WebhookEditCtrl(
     $scope.certDateClass = function (date) {
         return (moment().diff(date) < 0) ? 'green' : 'red';
     };
+
+    $scope.$on('telemetry:esc', function ($event) {
+        if ($event.defaultPrevented) {
+            return;
+        }
+
+        $state.go('app.config', {tab: 'webhooks'});
+    });
 }
 
 statesModule.controller('WebhookEditCtrl', WebhookEditCtrl);

--- a/app/js/states/policies/controllers/view.policy.controller.js
+++ b/app/js/states/policies/controllers/view.policy.controller.js
@@ -7,6 +7,7 @@ const statesModule = require('../../');
  */
 function ViewPolicyCtrl($filter,
                         $location,
+                        $state,
                         $stateParams,
                         $scope,
                         gettextCatalog,
@@ -131,6 +132,16 @@ function ViewPolicyCtrl($filter,
 
     $scope.$on('reload:data', function () {
         getData();
+    });
+
+    $scope.$on('telemetry:esc', function ($event) {
+        if ($event.defaultPrevented) {
+            return;
+        }
+
+        if ($state.current.name === 'app.view-policy') {
+            $state.go('app.list-policies');
+        }
     });
 
     getData();


### PR DESCRIPTION
# **issue #345**

![gifrecord_2018-01-22_153424](https://user-images.githubusercontent.com/19577027/35243138-d4bcaf9c-ff89-11e7-93ec-8dcb24509c4f.gif)
![gifrecord_2018-01-22_153344](https://user-images.githubusercontent.com/19577027/35243139-d73eecc6-ff89-11e7-91e6-7c550e2487d4.gif)

@jharting I added esc-navigation to take you back to the config page from editing webhooks, but I am not sure if it necessary or what you had in mind when drilling down into a subject (actions, policies, etc.) and using esc to go up a level. Would you like me to keep this in or take it out?

