### PR TITLE
fix ansible-icon

### DIFF
--- a/app/js/components/ansibleIcon/ansibleIcon.directive.js
+++ b/app/js/components/ansibleIcon/ansibleIcon.directive.js
@@ -46,9 +46,9 @@ function ansibleIconCtrl($scope, gettextCatalog) {
 function ansibleIcon() {
     return {
         scope: {
-            value: '=',
-            showTooltip: '=',
-            showPlannerLine: '=',
+            value: '<',
+            showTooltip: '<',
+            showPlannerLine: '<',
             white: '<',
             hideLabel: '<'
         },

--- a/app/js/components/ansibleIcon/ansibleIcon.jade
+++ b/app/js/components/ansibleIcon/ansibleIcon.jade
@@ -1,3 +1,3 @@
-span.ansible-icon.svg(tooltip='{{:: tooltip}}', ng-class='svgClass')
-  md-icon(md-svg-src="{{:: icon}}" alt="{{:: tooltip}}")
+span.ansible-icon.svg(tooltip='{{tooltip}}', ng-class='svgClass')
+  md-icon(md-svg-src="{{icon}}" alt="{{tooltip}}")
   span.text(ng-hide='hideLabel') {{:: supportText}}


### PR DESCRIPTION
the way ansible-icon is used with for example planner service or actions page 3 requires that it does not use one-time bindings