### PR TITLE
Adding smoketest gulp tasks and notes

### DIFF
--- a/gulp/tasks/test.js
+++ b/gulp/tasks/test.js
@@ -1,13 +1,13 @@
+/*global require*/
 'use strict';
 
-var gulp = require('gulp');
-var runSequence = require('run-sequence');
+const gulp = require('gulp');
+const shell = require('gulp-shell');
 
 // only the unit tests are working currently
 gulp.task('test', ['unit']);
 
-/*
-gulp.task('test', ['server'], function () {
-    return runSequence('unit', 'protractor');
-});
-*/
+gulp.task('smoke:chromedriver', shell.task('./node_modules/chromedriver/bin/chromedriver'));
+gulp.task('smoke:chromedriver:background', shell.task('source ./tmp/env.sh && xvfb-run -a --server-args="-screen 0 1600x1200x24" ./node_modules/chromedriver/bin/chromedriver'));
+gulp.task('smoke:run', shell.task('source ./tmp/env.sh && ./node_modules/nightwatch/bin/nightwatch smoketest/insightsTest.js'));
+

--- a/gulp/tasks/watch.js
+++ b/gulp/tasks/watch.js
@@ -18,3 +18,9 @@ gulp.task('watch', [ 'browserSync', 'server'], function () {
         runSequence ('views', 'bro');
     });
 });
+
+gulp.task('smoke:watch', [], function () {
+    gulp.watch(config.views.watch.concat(exclude), ['smoke:run']);
+    gulp.watch('./smoketest/*js', ['smoke:run']);
+});
+

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "gulp-rename": "~1.2.x",
     "gulp-replace": "^0.6.1",
     "gulp-sass": "^3.1.0",
+    "gulp-shell": "^0.6.5",
     "gulp-sourcemaps": "~2.6.x",
     "gulp-streamify": "~1.0.x",
     "gulp-uglify": "~2.1.x",

--- a/smoketest/notes
+++ b/smoketest/notes
@@ -1,3 +1,0 @@
-npm install --save-dev chromedriver nightwatch
-./node_modules/chromedriver/bin/chromedriver
-./node_modules/nightwatch/bin/nightwatch smoketest/insightsTest.js

--- a/smoketest/notes.md
+++ b/smoketest/notes.md
@@ -1,0 +1,25 @@
+# Setup
+1. Make sure you `npm install`
+1. Setup ./tmp/env.sh with the following in it
+```
+#!/bin/bash
+set -a
+TEST_URL=https://prod.foo.redhat.com:1337/insightsbeta
+TEST_USERNAME=YOUR USER
+TEST_PASSWORD=YOUR PASS
+```
+
+# Usage
+
+## Basic usage:
+$ gulp smoke:chromedriver
+$ gulp smoke:run
+
+## To run in the background
+Make sure XVFB is installed, then:
+$ gulp smoke:chromedriver:background
+$ gulp run
+
+## Watch
+$ gulp smoke:chromedriver or gulp smoke:chromedriver:backgrond
+$ gulp smoke:watch


### PR DESCRIPTION
@mattnolting @ryelo @Kinlaw 

Can you make sure the smoke test gulp tasks wfy?

On Mac I am not sure if XVFB is available so the background task might not work.