### PR TITLE
fixes digests score variance on new accounts

### DIFF
--- a/app/js/components/gaugeMarker/gaugeMarker.directive.js
+++ b/app/js/components/gaugeMarker/gaugeMarker.directive.js
@@ -7,10 +7,7 @@ const priv = {};
 /**
  * @ngInject
  */
-function gaugeMarkerController($scope, gettextCatalog) {
-
-    const MAX_SCORE = 850;
-    const MIN_SCORE = 250;
+function gaugeMarkerController($scope, gettextCatalog, MAX_SCORE, MIN_SCORE) {
 
     priv.getString = (str) => {
         return str + ' ' + $scope.difference + ' ' + gettextCatalog.getString('points');

--- a/app/js/constants/constants.js
+++ b/app/js/constants/constants.js
@@ -32,6 +32,10 @@ constantsModule.constant(
         resourceCount: 'X-Resource-Count'
     });
 
+// digests min and max scores
+constantsModule.constant('MAX_SCORE', 850);
+constantsModule.constant('MIN_SCORE', 250);
+
 // These are avalible via a service, but the service is not a production service.
 // For speed and reliability storing them here for now
 // We can move them to InsightsAPI if we want,

--- a/app/js/states/digests/digests.controller.js
+++ b/app/js/states/digests/digests.controller.js
@@ -14,7 +14,7 @@ const TIME_PERIOD = 30;
  * @ngInject
  */
 function DigestsCtrl($scope, $http, DigestService, System, Rule, AccountService,
-                     InventoryService, Severities, InsightsConfig, User) {
+                     InventoryService, Severities, InsightsConfig, User, MIN_SCORE) {
 
     function getDirection(data) {
         const direction = data[1] - data[0];
@@ -128,6 +128,7 @@ function DigestsCtrl($scope, $http, DigestService, System, Rule, AccountService,
             page: 0
         });
         let rulePromise = Rule.getRulesWithHits();
+        let prevScore = MIN_SCORE;
 
         $scope.loading = true;
 
@@ -207,13 +208,14 @@ function DigestsCtrl($scope, $http, DigestService, System, Rule, AccountService,
             $scope.latest_score = takeRight(digestBase.scores, 1)[0];
             window.scope = $scope;
 
-            $scope.score_difference = $scope.latest_score -
-                digestBase.scores[digestBase.scores.length - 2];
+            // if last digest score was 0 then change to minimum score
+            prevScore = digestBase.scores[digestBase.scores.length - 2] || MIN_SCORE;
+            $scope.score_difference = $scope.latest_score - prevScore;
 
             // max score is 850, min is 250.  Levels calculated by
             //  separating the 600 range into 4 segments and dividing
             //  score by segment length (150)
-            const level = Math.ceil(($scope.latest_score - 250) / 150) || 1;
+            const level = Math.ceil(($scope.latest_score - MIN_SCORE) / 150) || 1;
             const scoreDiv = angular.element(
                 document.querySelector('.gauge.gauge-circle.score'));
             scoreDiv.addClass('score_lvl' + level);


### PR DESCRIPTION
Fixes #243 

If this gets reviewed after today you can test this change by changing line 214 in digests.controller.js to use a digestBase.score that is 0.