### PR TITLE
Removing productSelect from actions donut

### DIFF
--- a/app/js/components/rhDonut/rhDonut.directive.js
+++ b/app/js/components/rhDonut/rhDonut.directive.js
@@ -89,8 +89,7 @@ function rhaTelemetryDonut(
                                 const elem = document.querySelector(selector);
                                 angular.element(elem).on('touchend click', function () {
                                     $state.go('app.topic', {
-                                        id: category.toLowerCase(),
-                                        product: FilterService.getSelectedProduct()
+                                        id: category.toLowerCase()
                                     });
                                 });
                             });


### PR DESCRIPTION
Actions donut was still using productSelect which threw an error and wouldn't let you click on it.