### PR TITLE
Re-enable Pendo. User.async must be called after User.init. Also md5 the username

### DIFF
--- a/app/js/services/analytics.service.js
+++ b/app/js/services/analytics.service.js
@@ -2,6 +2,7 @@
 'use strict';
 
 var servicesModule = require('./');
+var md5 = require('md5');
 var priv = {};
 var pub = {};
 
@@ -47,12 +48,13 @@ priv.pendoBlob = function () { (function(p,e,n,d,o){var v,w,x,y,z;o=p[d]=p[d]||{
 function AnalyticsService(InsightsConfig, $location, IgnoreAccountList, User) {
     pub.initPendo = function () {
         priv.pendoBlob();
+        User.init();
         User.asyncCurrent((user) => {
             if (typeof window.pendo !== 'undefined') {
                 const pendoConf = {
                     apiKey: 'f210c485-387f-43ad-4eee-f55bab22507f',
                     visitor: {
-                        id: user.sso_username,
+                        id: md5(user.sso_username),
                         internal: user.is_internal,
                         lang: user.locale
                     },

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "karma-should": "~1.0.x",
     "lodash": "~4.17.x",
     "map-stream": "~0.0.x",
+    "md5": "^2.2.1",
     "merge-stream": "~1.0.x",
     "moment": "~2.20.x",
     "moment-timezone": "~0.5.x",


### PR DESCRIPTION
Not sure when the User.init part regressed. I guess we used to call User.init
before calling the Analytics service, and now we dont.