### PR TITLE
Removes "More Info" dropdown menu item from "help"

### DIFF
--- a/app/js/components/topbar/topbar.jade
+++ b/app/js/components/topbar/topbar.jade
@@ -31,8 +31,6 @@
       md-menu-item
         a(href='https://access.redhat.com/documentation/en/red-hat-insights/', target='_blank', translate) Product Documentation
       md-menu-item
-        a(ui-sref='info.info', translate) More Info
-      md-menu-item
         a(ui-sref='info.security', translate) Security
       md-menu-item
         a(href='/help/browsers', target='_self', translate, ng-if="isPortal") Browser Support


### PR DESCRIPTION
fixes RHINSIGHTS-71
fixes https://bugzilla.redhat.com/show_bug.cgi?id=1575689

its like #497 cept not from a fork